### PR TITLE
商品一覧表示機能の一部修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :days_to_ship
 
   belongs_to :user
-  has_one_attached :image
+  has_one_attached :image, dependent: :destroy
 
   validates :image, :goods, :details, :category_id, :status_id, :shipping_fee_burden_id, :shipping_area_id, \
             :days_to_ship_id, :price, presence: true

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,7 +159,7 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% unless @items %>
+      <% unless @items.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>


### PR DESCRIPTION
# What
商品一覧表示機能はすでにLGTMを頂いていましたが商品が無い場合のダミー画像の表示がうまく出来ていないことに気づいたため修正しました。メンターさんに確認したところ再度ブランチを作ってプルリクエストを送られた方が良いとのことでしたのでお手数ですがご対応のほどよろしくおねがい致しします。

# Why
商品がない場合のダミー画像の表示

https://gyazo.com/6c9812971c4596f432796571ad3d4b5d


